### PR TITLE
Specify parent group for customize

### DIFF
--- a/helm-hunks.el
+++ b/helm-hunks.el
@@ -47,7 +47,8 @@
 (require 'subr-x)
 
 (defgroup helm-hunks nil
-  "A helm interface for git hunks")
+  "A helm interface for git hunks"
+  :group 'helm)
 
 (defcustom helm-hunks-refresh-hook
   nil


### PR DESCRIPTION
This also fixes following byte-compile warning.

```
helm-hunks.el:49:1:Warning: defgroup for ‘helm-hunks’ fails to specify containing group
```